### PR TITLE
CH-60: Add 'Check All' checkbox on to of 'Assign CH Fund'

### DIFF
--- a/CRM/Chfunds/Form/CHFunds.php
+++ b/CRM/Chfunds/Form/CHFunds.php
@@ -25,6 +25,8 @@ class CRM_Chfunds_Form_CHFunds extends CRM_Core_Form {
     foreach ($optionValues as $value) {
       $chFunds[$value['value']] = $value['label'];
     }
+
+    $this->addElement('checkbox', "ch_funds_check_all", NULL, ts('Check all'));
     foreach ($chFunds as $chFund => $label) {
       $this->addElement('checkbox', "ch_funds[$chFund]", NULL, $label);
     }

--- a/chfunds.php
+++ b/chfunds.php
@@ -154,12 +154,10 @@ function chfunds_civicrm_pageRun(&$page) {
     $chFundLinks = $chFunds = [];
     $chFundsByFinancialType = E::getCHFundsByFinancialType();
     foreach ($rows as $id => $row) {
+      $chFunds[$count] = CRM_Utils_Array::value($id, $chFundsByFinancialType, '');
+      $chFundLinks[$count] = NULL;
       if (CRM_Core_Permission::check('assign CH Fund') || $row['name'] == 'Unassigned CH Fund') {
         $chFundLinks[$count] = CRM_Utils_System::url('civicrm/chfunds', 'reset=1&financial_type_id=' . $row['id']);
-        $chFunds[$count] = CRM_Utils_Array::value($id, $chFundsByFinancialType, '');
-      }
-      else {
-        $chFundLinks[$count] = $chFunds[$count] = NULL;
       }
 
       $count++;

--- a/templates/CRM/Chfunds/Form/CHFunds.tpl
+++ b/templates/CRM/Chfunds/Form/CHFunds.tpl
@@ -10,6 +10,7 @@
           <tr>
             <td class="label"><label>Assign CH Funds</label></td>
             <td class="content">
+              {$form.ch_funds_check_all.html}
               <ul class="crm-checkbox-list">
               {foreach from=$form.ch_funds item="ch_funds_val"}
                 <li class="{cycle values="even-row,odd-row"}">
@@ -43,3 +44,19 @@
 {include file="CRM/common/formButtons.tpl" location="bottom"}
 </div>
 </div>
+
+{literal}
+<script type="text/javascript">
+CRM.$(function($) {
+  $("#ch_funds_check_all").on('click', function() {
+    $("input[name^='ch_funds\[']").prop('checked', $(this).prop("checked"));
+    if ($(this).prop("checked")) {
+      $("label[for='ch_funds_check_all']").text(ts('Uncheck all'));
+    }
+    else {
+      $("label[for='ch_funds_check_all']").text(ts('Check all'));
+    }
+  });
+});
+</script>
+{/literal}


### PR DESCRIPTION
This PR include following changes:
1. Adds 'Check all' checkbox in top of 'Assign CH Fund' widget
2. Show all CH Funds on Funds admin page irrespective of permission