### PR TITLE
CRM-307: Schema change for civicrm_ch_contribution_batch table

### DIFF
--- a/CRM/Chfunds/Upgrader.php
+++ b/CRM/Chfunds/Upgrader.php
@@ -26,6 +26,18 @@ class CRM_Chfunds_Upgrader extends CRM_Chfunds_Upgrader_Base {
     return TRUE;
   }
 
+  public function upgrade_1300() {
+    $this->ctx->log->info('Applying update 1.3');
+    $sql = "
+    ALTER TABLE `civicrm_ch_contribution_batch`
+      CHANGE `ch_fund` `ch_fund` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+      CHANGE `fund` `fund` INT(11) NOT NULL,
+      CHANGE `contribution_id` `contribution_id` INT(11) NOT NULL;
+    ";
+    CRM_Core_DAO::executeQuery($sql);
+    return TRUE;
+  }
+
   // By convention, functions that look like "function upgrade_NNNN()" are
   // upgrade tasks. They are executed in order (like Drupal's hook_update_N).
 

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://github.com/JMAConsulting/chfunds/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2019-11-16</releaseDate>
-  <version>1.2</version>
+  <releaseDate>2020-02-19</releaseDate>
+  <version>1.3</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>5.20</ver>

--- a/sql/auto_install.sql
+++ b/sql/auto_install.sql
@@ -96,8 +96,9 @@ CREATE TABLE `civicrm_option_value_ch` (
 )    ;
 
 CREATE TABLE IF NOT EXISTS `civicrm_ch_contribution_batch` (
-   `id` INT NOT NULL AUTO_INCREMENT , `ch_fund` VARCHAR(10) NOT NULL ,
-   `fund` INT(4) NOT NULL ,
-   `contribution_id` INT(10) NOT NULL ,
+   `id` INT NOT NULL AUTO_INCREMENT ,
+   `ch_fund` varchar(255) COLLATE utf8_unicode_ci NOT NULL ,
+   `fund` INT(11) NOT NULL ,
+   `contribution_id` INT(11) NOT NULL ,
   PRIMARY KEY (`id`)
 ) ENGINE = InnoDB;


### PR DESCRIPTION
I have added the upgrade and install code to change the schema of ```civicrm_ch_contribution_batch``` table where : 
1. ```ch_fund``` length is increased to 255 from 10
2. ```fund length``` is increased to 11 from 4
3. ```contribution_id``` is increased to 11 from 10 