### PR TITLE
CRM-307 Add in unit test proving issue around ch_fund column length i…

### DIFF
--- a/tests/phpunit/api/v3/ChContribution/CreateTest.php
+++ b/tests/phpunit/api/v3/ChContribution/CreateTest.php
@@ -165,6 +165,7 @@ class api_v3_ChContribution_CreateTest extends \PHPUnit\Framework\TestCase imple
     $this->callAPISuccess('Contribution', 'delete', ['id' => $contribution['id']]);
     $this->callAPISuccess('OptionValue', 'delete', ['id' => $chFund['id']]);
     $this->callAPISuccess('Contact', 'delete', ['id' => $contact, 'skip_undelete' => TRUE]);
+    CRM_Core_DAO::executeQuery("DELETE FROM civicrm_ch_contribution_batch WHERE contribution_id = %1", [1 => [$contribution['id'], 'Positive']]);
   }
 
 }


### PR DESCRIPTION
…n batch table

@joeMurray @monishdeb I have added a unit test which i believe demonstrates the problem. You can create a CH Fund with an option value char length > 10 for the actual value but then borks when it tries to insert into the batch table.